### PR TITLE
feat: allow ignoring protoc version comments in go generate check

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -88,13 +88,13 @@ jobs:
           run: |
             git clean -fd # make sure there aren't untracked files / directories
             if [[ -n "$IGNORE_PROTOC_VERSION_COMMENTS" ]]; then
-              find . -name '*.pb.go' -print0 | xargs -0 sed -i '/^\/\/.*protoc.*v/d'
+              find . -name '*.pb.go' -print0 | xargs -0 -r sed -i '/^\/\/.*protoc.*v/d'
               git add .
               git commit -m "chore: remove protoc version comments"
             fi
             go generate -x ./...
             if [[ -n "$IGNORE_PROTOC_VERSION_COMMENTS" ]]; then
-              find . -name '*.pb.go' -print0 | xargs -0 sed -i '/^\/\/.*protoc.*v/d'
+              find . -name '*.pb.go' -print0 | xargs -0 -r sed -i '/^\/\/.*protoc.*v/d'
             fi
             git add .
             # check if go generate modified or added any files

--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -5,6 +5,9 @@ on:
       go-version:
         required: false
         type: string
+      go-generate-ignore-protoc-version-comments:
+        required: false
+        type: boolean
 
 jobs:
   unit:
@@ -79,12 +82,23 @@ jobs:
       - name: go generate
         uses: protocol/multiple-go-modules@v1.2
         if: (success() || failure()) && fromJSON(steps.config.outputs.json).gogenerate == true
+        env:
+          IGNORE_PROTOC_VERSION_COMMENTS: ${{ inputs.go-generate-ignore-protoc-version-comments }}
         with:
           run: |
             git clean -fd # make sure there aren't untracked files / directories
+            if [[ -n "$IGNORE_PROTOC_VERSION_COMMENTS" ]]; then
+              find . -name '*.pb.go' -print0 | xargs -0 sed -i '/^\/\/.*protoc.*v/d'
+              git add .
+              git commit -m "chore: remove protoc version comments"
+            fi
             go generate -x ./...
+            if [[ -n "$IGNORE_PROTOC_VERSION_COMMENTS" ]]; then
+              find . -name '*.pb.go' -print0 | xargs -0 sed -i '/^\/\/.*protoc.*v/d'
+            fi
+            git add .
             # check if go generate modified or added any files
-            if ! $(git add . && git diff-index HEAD --exit-code --quiet); then
+            if ! $(git diff-index HEAD --exit-code --quiet); then
               echo "go generated caused changes to the repository:"
               git status --short
               exit 1

--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -90,6 +90,8 @@ jobs:
             if [[ -n "$IGNORE_PROTOC_VERSION_COMMENTS" ]]; then
               find . -name '*.pb.go' -print0 | xargs -0 -r sed -i '/^\/\/.*protoc.*v/d'
               git add .
+              git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git config --global user.name "github-actions[bot]"
               git commit -m "chore: remove protoc version comments"
             fi
             go generate -x ./...

--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           run: |
             git clean -fd # make sure there aren't untracked files / directories
-            if [[ -n "$IGNORE_PROTOC_VERSION_COMMENTS" ]]; then
+            if [[ "$IGNORE_PROTOC_VERSION_COMMENTS" == "true" ]]; then
               find . -name '*.pb.go' -print0 | xargs -0 -r sed -i '/^\/\/.*protoc.*v/d'
               git add .
               git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -95,7 +95,7 @@ jobs:
               git diff --cached --quiet || git commit -m "chore: remove protoc version comments"
             fi
             go generate -x ./...
-            if [[ -n "$IGNORE_PROTOC_VERSION_COMMENTS" ]]; then
+            if [[ "$IGNORE_PROTOC_VERSION_COMMENTS" == "true" ]]; then
               find . -name '*.pb.go' -print0 | xargs -0 -r sed -i '/^\/\/.*protoc.*v/d'
             fi
             git add .

--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -92,7 +92,7 @@ jobs:
               git add .
               git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
               git config --global user.name "github-actions[bot]"
-              git commit -m "chore: remove protoc version comments"
+              git diff --cached --quiet || git commit -m "chore: remove protoc version comments"
             fi
             go generate -x ./...
             if [[ -n "$IGNORE_PROTOC_VERSION_COMMENTS" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- ability to ignore protoc version comments in `go generate` check
 
 ## [0.0.12] - 2023-08-23
 ### Changed


### PR DESCRIPTION
Resolves https://github.com/pl-strflt/uci/issues/26

Tested in https://github.com/libp2p/go-libp2p/pull/2603. I'll create a PR to go-libp2p that enables the newly added option after I release the new patch version of uCI which will be shortly after this is merged.