### PR TITLE
Add write perm to id token to allow publishing with provenance

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -213,6 +213,8 @@ jobs:
     needs: [release-check]
     runs-on: ubuntu-latest
     if: needs.release-check.outputs.release == 'true'
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Publishing to npm with provenance statements helps reduce the risk of supply chain attacks:

https://docs.npmjs.com/generating-provenance-statements