### PR TITLE
add contents perm to token

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -215,6 +215,7 @@ jobs:
     if: needs.release-check.outputs.release == 'true'
     permissions:
       id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
It turns out you need this too in order to access the `git/tree` resource while publishing with provenance.