### PR TITLE
feat: added chrome secrets support to the js-test-and-release workflow

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -25,6 +25,14 @@ on:
         required: false
       CODECOV_TOKEN:
         required: false
+      CHROME_CLIENT_ID:
+        required: false
+      CHROME_CLIENT_SECRET:
+        required: false
+      CHROME_REFRESH_TOKEN:
+        required: false
+      CHROME_EXTENSION_ID:
+        required: false
 
 defaults:
   run:
@@ -275,3 +283,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID || vars.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID || vars.CHROME_EXTENSION_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- chrome secrets support to the `js-test-and-release` workflow
 
 ## [1.0.30] - 2025-08-04
 ### Added

--- a/templates/.github/workflows/js-test-and-release.yml
+++ b/templates/.github/workflows/js-test-and-release.yml
@@ -26,3 +26,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+      CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+      CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+      CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}


### PR DESCRIPTION
This is a proposal for how we could add support for chrome web store publishing to the js-test-and-release workflow. When deciding whether to include this proposal, we have to weigh in whether this addition would constitute an overgeneralisation of the workflow. It is possible that this particular use case might be better served by a job that simply follows js-test-and-release. Until we make a decision to proceed with this proposal, this PR will stay in draft.