### PR TITLE
fix(release-check): pass -version to gorelease

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -208,6 +208,7 @@ jobs:
         env:
           LANGUAGE: ${{ github.event.pull_request.base.repo.language }}
           PREV_TAG: ${{ steps.prev.outputs.tag }}
+          VERSION: v${{ steps.version.outputs.version }}
         # see https://github.com/golang/exp/commits/master/cmd/gorelease
         run: |
           git config advice.detachedHead false
@@ -219,7 +220,11 @@ jobs:
             echo "\`gorelease\` says:" >> $GITHUB_OUTPUT
             echo "\`\`\`" >> $GITHUB_OUTPUT
             echo "Run gorelease"
-            ((gorelease -base "$PREV_TAG") 2>&1 || true) | tee -a $GITHUB_OUTPUT
+            # Pass -version so gorelease uses the working tree as the release candidate.
+            # Without it, gorelease resolves the candidate via MVS over the module graph,
+            # which picks the wrong version when a dependency transitively requires an
+            # older version of the module being released (e.g. boxo -> kad-dht).
+            ((gorelease -base "$PREV_TAG" -version "$VERSION") 2>&1 || true) | tee -a $GITHUB_OUTPUT
             echo "\`\`\`" >> $GITHUB_OUTPUT
             echo "" >> $GITHUB_OUTPUT
             echo "\`gocompat\` says:" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR fixes false-positive detection of breaking API changes which incorrectly suggested bump of version more than necessary.

Without `-version`, `gorelease` resolves the release candidate via MVS over the module graph instead of reading the working tree. When a dependency transitively requires an older version of the module being released (e.g. boxo depends on go-libp2p-kad-dht, which depends on boxo), MVS picks that older version as the candidate and the diff report comes out inverted, flagging all symbols introduced in the current release as "removed" and suggesting an unnecessary minor bump.

Example: https://github.com/libp2p/go-libp2p-kad-dht/pull/1245#issuecomment-4281361854

Passing `-version` (already computed and validated via semver earlier in the workflow) forces `gorelease` to use the working tree as the candidate, restoring correct base-to-head comparison.

cc @galargh 