### PR TITLE
Pin GitHub Actions to SHAs

### DIFF
--- a/.github/actions/inspect-releaser/README.md
+++ b/.github/actions/inspect-releaser/README.md
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: releaser
-        uses: ipdxco/unified-github-workflows/.github/actions/inspect-releaser@main
+        uses: ipdxco/unified-github-workflows/.github/actions/inspect-releaser@6d814de11369bb725d26e8d350ac62fe6811ff0a # main
         with:
           artifacts-url: ${{ github.event.inputs.artifacts-url || github.event.workflow_run.artifacts_url }}
       - if: ${{ steps.releaser.outputs.id == '' }}

--- a/.github/actions/inspect-releaser/action.yml
+++ b/.github/actions/inspect-releaser/action.yml
@@ -34,7 +34,7 @@ runs:
   using: composite
   steps:
     - id: workflow-run
-      uses: ipdxco/workflow-run-context@v1
+      uses: ipdxco/workflow-run-context@492ea3967eb2ca7ed76b7888b42fa7649addd975 # v1.1.1
       with:
         artifacts-url: ${{ inputs.artifacts-url }}
         artifact-names: ${{ inputs.artifact-name }}

--- a/.github/workflows/add-label-by-query.yml
+++ b/.github/workflows/add-label-by-query.yml
@@ -26,7 +26,7 @@ jobs:
           QUERY: ${{ github.event.inputs.query }}
           LABEL: ${{ github.event.inputs.label }}
           DRY_RUN: ${{ github.event.inputs.dry-run }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/check-3rd-party.yml
+++ b/.github/workflows/check-3rd-party.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       targets: ${{ steps.set-matrix.outputs.targets }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: set-matrix
         run: |
           TARGETS=$(find . -type f -name "*.yml" | sed "s|^\./||" | grep -v workflow-templates/header.yml | jq -R -s -c 'split("\n")[:-1]')
@@ -23,7 +23,7 @@ jobs:
         file: ${{ fromJSON(needs.matrix.outputs.targets) }}
     name: ${{ matrix.file }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/render-templates
       - name: Run check
         env:

--- a/.github/workflows/check-yaml.yml
+++ b/.github/workflows/check-yaml.yml
@@ -12,9 +12,9 @@ jobs:
   check-yaml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/render-templates
-      - uses: ipdxco/validate-yaml-schema@v1
+      - uses: ipdxco/validate-yaml-schema@9ad8180446c50787626d798c2230f80fe1d974d1 # v1.0.1
         with:
           yamlSchemasJson: |
             {

--- a/.github/workflows/copy-templates.yml
+++ b/.github/workflows/copy-templates.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       defaults: ${{ steps.defaults.outputs.defaults }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: defaults
         name: Read defaults
         run: |

--- a/.github/workflows/create-prs.yml
+++ b/.github/workflows/create-prs.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           BRANCH: ${{ github.event.inputs.branch }}
           DRY_RUN: ${{ github.event.inputs.dry-run }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.UCI_GITHUB_TOKEN }}
           retries: 0

--- a/.github/workflows/delete-branches.yml
+++ b/.github/workflows/delete-branches.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           BRANCH: ${{ github.event.inputs.branch }}
           DRY_RUN: ${{ github.event.inputs.dry-run }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.UCI_GITHUB_TOKEN }}
           retries: 0

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -27,7 +27,7 @@ jobs:
       batches: ${{ steps.matrix.outputs.result }}
     steps:
       - id: matrix
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           FILTER: ${{ inputs.filter }}
         with:

--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -52,13 +52,13 @@ jobs:
       - name: Create GitHub App installation token
         id: checkout-app
         if: steps.secrets.outputs.CHECKOUT_APP_ID == 'true' && steps.secrets.outputs.CHECKOUT_PRIVATE_KEY == 'true'
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.CHECKOUT_APP_ID }}
           private-key: ${{ secrets.CHECKOUT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Check out the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           token: ${{ steps.checkout-app.outputs.token || secrets.CHECKOUT_TOKEN || github.token }}
@@ -77,20 +77,20 @@ jobs:
           fi
       - name: Check out the latest stable version of Go
         id: stable
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
           cache: false
       - name: Read the Unified GitHub Workflows configuration
         id: config
-        uses: ipdxco/unified-github-workflows/.github/actions/read-config@main
+        uses: ipdxco/unified-github-workflows/.github/actions/read-config@6d814de11369bb725d26e8d350ac62fe6811ff0a # main
       - name: Read the go.mod file
         id: go-mod
-        uses: ipdxco/unified-github-workflows/.github/actions/read-go-mod@main
+        uses: ipdxco/unified-github-workflows/.github/actions/read-go-mod@6d814de11369bb725d26e8d350ac62fe6811ff0a # main
       - name: Set up the Go version read from the go.mod file
         id: go
         if: (inputs.go-version || fromJSON(steps.go-mod.outputs.json).Go) != steps.stable.outputs.go-version || inputs.go-cache != 'false'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ inputs.go-version || fromJSON(steps.go-mod.outputs.json).Go }}
           cache: ${{ inputs.go-cache }}
@@ -170,7 +170,7 @@ jobs:
             go get github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$version ||
             go get github.com/golangci/golangci-lint/cmd/golangci-lint@$version
       - name: Check that go.mod is tidy
-        uses: protocol/multiple-go-modules@v1.4
+        uses: protocol/multiple-go-modules@ac694baecddc63fc5ba8fe8262d46659fbbf911d # v1.4
         with:
           run: |
             go mod tidy
@@ -189,19 +189,19 @@ jobs:
           fi
       - name: go vet
         if: success() || failure() # run this step even if the previous one failed
-        uses: protocol/multiple-go-modules@v1.4
+        uses: protocol/multiple-go-modules@ac694baecddc63fc5ba8fe8262d46659fbbf911d # v1.4
         with:
           run: go vet ./...
       - name: staticcheck
         if: success() || failure() # run this step even if the previous one failed
-        uses: protocol/multiple-go-modules@v1.4
+        uses: protocol/multiple-go-modules@ac694baecddc63fc5ba8fe8262d46659fbbf911d # v1.4
         with:
           run: |
             set -o pipefail
             staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
       - name: golangci-lint run
         if: (success() || failure()) && hashFiles('.golangci.yml', '.golangci.toml', '.golangci.json', '.golangci.yaml') != ''
-        uses: protocol/multiple-go-modules@v1.4
+        uses: protocol/multiple-go-modules@ac694baecddc63fc5ba8fe8262d46659fbbf911d # v1.4
         env:
           NEW_FROM_REV: ${{
               steps.github.outputs.base_sha && !(
@@ -218,7 +218,7 @@ jobs:
         with:
           run: golangci-lint run --disable govet --disable staticcheck --new=false --new-from-patch= --new-from-rev=$NEW_FROM_REV --verbose
       - name: go generate
-        uses: protocol/multiple-go-modules@v1.4
+        uses: protocol/multiple-go-modules@ac694baecddc63fc5ba8fe8262d46659fbbf911d # v1.4
         if: (success() || failure()) && fromJSON(steps.config.outputs.json).gogenerate == true
         env:
           IGNORE_PROTOC_VERSION_COMMENTS: ${{ inputs.go-generate-ignore-protoc-version-comments }}

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Create GitHub App installation token
         id: checkout-app
         if: steps.secrets.outputs.CHECKOUT_APP_ID == 'true' && steps.secrets.outputs.CHECKOUT_PRIVATE_KEY == 'true'
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.CHECKOUT_APP_ID }}
           private-key: ${{ secrets.CHECKOUT_PRIVATE_KEY }}
@@ -90,22 +90,22 @@ jobs:
         #   subsequent 'shell: bash' steps will use msys2 instead of gitbash
         run: echo "C:/msys64/usr/bin" >> $GITHUB_PATH
       - name: Check out the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           token: ${{ steps.checkout-app.outputs.token || secrets.CHECKOUT_TOKEN || github.token }}
       - name: Check out the latest stable version of Go
         id: stable
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
           cache: false
       - name: Read the Unified GitHub Workflows configuration
         id: config
-        uses: ipdxco/unified-github-workflows/.github/actions/read-config@main
+        uses: ipdxco/unified-github-workflows/.github/actions/read-config@6d814de11369bb725d26e8d350ac62fe6811ff0a # main
       - name: Read the go.mod file
         id: go-mod
-        uses: ipdxco/unified-github-workflows/.github/actions/read-go-mod@main
+        uses: ipdxco/unified-github-workflows/.github/actions/read-go-mod@6d814de11369bb725d26e8d350ac62fe6811ff0a # main
       - name: Determine the Go version to use based on the go.mod file
         id: go
         env:
@@ -145,7 +145,7 @@ jobs:
           echo "GO386FLAGS=-v $GO386FLAGS" >> $GITHUB_ENV
           echo "GORACEFLAGS=-v $GORACEFLAGS" >> $GITHUB_ENV
       - name: Set up the Go version read from the go.mod file
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         if: steps.go.outputs.version != steps.stable.outputs.go-version || inputs.go-cache != 'false'
         with:
           go-version: ${{ steps.go.outputs.version }}
@@ -159,7 +159,7 @@ jobs:
         if: hashFiles('./.github/actions/go-test-setup') != ''
       - name: Run tests
         if: contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
-        uses: protocol/multiple-go-modules@v1.4
+        uses: protocol/multiple-go-modules@ac694baecddc63fc5ba8fe8262d46659fbbf911d # v1.4
         env:
           GOFLAGS: ${{ format('{0} {1}', env.GOTESTFLAGS, env.GOFLAGS) }}
           CGO_ENABLED: ${{ toJSON(fromJSON(steps.config.outputs.json).cgo) != 'false' }}
@@ -171,7 +171,7 @@ jobs:
           contains(steps.config.outputs.json, '"skip32bit"') &&
           fromJSON(steps.config.outputs.json).skip32bit == false &&
           contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
-        uses: protocol/multiple-go-modules@v1.4
+        uses: protocol/multiple-go-modules@ac694baecddc63fc5ba8fe8262d46659fbbf911d # v1.4
         env:
           GOARCH: 386
           GOFLAGS: ${{ format('{0} {1}', env.GO386FLAGS, env.GOFLAGS) }}
@@ -185,7 +185,7 @@ jobs:
         if: matrix.os == 'ubuntu' &&
           fromJSON(steps.config.outputs.json).skipRace != true &&
           contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
-        uses: protocol/multiple-go-modules@v1.4
+        uses: protocol/multiple-go-modules@ac694baecddc63fc5ba8fe8262d46659fbbf911d # v1.4
         env:
           GOFLAGS: ${{ format('{0} {1}', env.GORACEFLAGS, env.GOFLAGS) }}
           CGO_ENABLED: ${{ toJSON(fromJSON(steps.config.outputs.json).cgo) != 'false' }}
@@ -196,7 +196,7 @@ jobs:
         run: echo "files=$(find . -type f -name 'module-coverage.txt' | tr -s '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
       - name: Upload coverage to Codecov
         if: steps.secrets.outputs.CODECOV_TOKEN == 'true'
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         env:
           OS: ${{ matrix.os }}
           GO: ${{ steps.go.outputs.version }}

--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -35,23 +35,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
 
   check:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
       - run: npm run --if-present lint
       - run: npm run --if-present dep-check
       - run: npm run --if-present doc-check
@@ -66,14 +66,14 @@ jobs:
         node: [lts/*]
       fail-fast: true
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: ${{ matrix.node }}
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
       - run: npm run --if-present test:node
-      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: node
           files: .coverage/*,packages/*/.coverage/*
@@ -85,14 +85,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
       - run: npm run --if-present test:chrome
-      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: chrome
           files: .coverage/*,packages/*/.coverage/*
@@ -103,14 +103,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
       - run: npm run --if-present test:chrome-webworker
-      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: chrome-webworker
           files: .coverage/*,packages/*/.coverage/*
@@ -121,14 +121,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
       - run: npm run --if-present test:firefox
-      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: firefox
           files: .coverage/*,packages/*/.coverage/*
@@ -139,14 +139,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
       - run: npm run --if-present test:firefox-webworker
-      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: firefox-webworker
           files: .coverage/*,packages/*/.coverage/*
@@ -162,15 +162,15 @@ jobs:
         node: [lts/*]
       fail-fast: true
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
       - run: npx playwright install-deps
       - run: npm run --if-present test:webkit
-      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: webkit
           files: .coverage/*,packages/*/.coverage/*
@@ -187,15 +187,15 @@ jobs:
         node: [lts/*]
       fail-fast: true
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
       - run: npx playwright install-deps
       - run: npm run --if-present test:webkit-webworker
-      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: webkit-webworker
           files: .coverage/*,packages/*/.coverage/*
@@ -207,14 +207,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
       - run: npx xvfb-maybe npm run --if-present test:electron-main
-      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: electron-main
           files: .coverage/*,packages/*/.coverage/*
@@ -225,14 +225,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
       - run: npx xvfb-maybe npm run --if-present test:electron-renderer
-      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: electron-renderer
           files: .coverage/*,packages/*/.coverage/*
@@ -251,7 +251,7 @@ jobs:
         env:
           BRANCHES: ${{ inputs.branches }}
           REF: ${{ github.ref }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const branches = JSON.parse(process.env.BRANCHES);
@@ -269,16 +269,16 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.release-check.outputs.release == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: lts/*
-      - uses: ipfs/aegir/actions/cache-node-modules@main
-      - uses: ipfs/aegir/actions/docker-login@main
+      - uses: ipfs/aegir/actions/cache-node-modules@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
+      - uses: ipfs/aegir/actions/docker-login@1c3f7a42f94ccfcab3fb0f785ac347afb8c9803c # main
         with:
           docker-token: ${{ secrets.DOCKER_TOKEN }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -23,7 +23,7 @@ jobs:
           QUERY: is:pr author:web3-bot state:open archived:false
           BRANCH: ${{ github.event.inputs.branch }}
           DRY_RUN: ${{ github.event.inputs.dry-run }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.UCI_GITHUB_TOKEN }}
           retries: 0

--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         pip install yq
     - name: Checkout ${{ matrix.repository }}
-      uses: actions/checkout@v5
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         path: ${{ matrix.repository }}
         repository: ${{ matrix.repository }}
@@ -72,14 +72,14 @@ jobs:
         submodules: recursive
         fetch-depth: 0
     - name: Checkout ${{ github.repository }}
-      uses: actions/checkout@v5
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         path: ${{ github.repository }}
         ref: ${{ github.ref }}
         fetch-depth: 0
     - id: github-cache
       name: Get ${{ matrix.repository }} GitHub info from cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ matrix.repository }}.info
         key: ${{ matrix.repository }}
@@ -115,7 +115,7 @@ jobs:
         echo "$eof" >> $GITHUB_OUTPUT
     - if: steps.github-cache.outputs.cache-hit != 'true'
       name: Save ${{ matrix.repository }} GitHub info to cache
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ matrix.repository }}.info
         key: ${{ matrix.repository }}

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -36,7 +36,7 @@ jobs:
         name: Retrieve PR information
         env:
           PULL_REQUEST: ${{ toJSON(github.event.pull_request) }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             let pr = JSON.parse(process.env.PULL_REQUEST);
@@ -58,10 +58,10 @@ jobs:
               pr = open[0];
             }
             core.setOutput('json', JSON.stringify(pr));
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: go-mod
-        uses: ipdxco/unified-github-workflows/.github/actions/read-go-mod@main
-      - uses: actions/setup-go@v6
+        uses: ipdxco/unified-github-workflows/.github/actions/read-go-mod@6d814de11369bb725d26e8d350ac62fe6811ff0a # main
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ fromJSON(steps.go-mod.outputs.json).Go || 'stable' }}
           cache: false
@@ -107,7 +107,7 @@ jobs:
         env:
           BRANCHES: ${{ inputs.branches }}
           BASE_REF: ${{ fromJSON(steps.pr.outputs.json).base.ref }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const branches = JSON.parse(process.env.BRANCHES);
@@ -237,7 +237,7 @@ jobs:
         working-directory: ${{ steps.version.outputs.root }}
       - id: release
         if: steps.tag.outputs.needed == 'true' && fromJSON(steps.pr.outputs.json).head.repo.full_name == fromJSON(steps.pr.outputs.json).base.repo.full_name
-        uses: galargh/action-gh-release@571276229e7c9e6ea18f99bad24122a4c3ec813f # https://github.com/galargh/action-gh-release/pull/1
+        uses: galargh/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           draft: true
           tag_name: ${{ steps.version.outputs.tag }}
@@ -316,7 +316,7 @@ jobs:
           fi
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Post message on PR
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         if: steps.tag.outputs.exists == 'false'
         with:
           header: release-check (${{ matrix.source }})
@@ -343,7 +343,7 @@ jobs:
           sed 's/[":<>|*?\r\n\\\/]/_/g' <<< "$SOURCE" | xargs -I {} -0 echo "name={}" | tee -a $GITHUB_OUTPUT
       - name: Upload release.json
         if: steps.release.outputs.id != ''
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.json.outputs.name }}
           path: release.json
@@ -353,7 +353,7 @@ jobs:
     outputs:
       json: ${{ toJSON(fromJSON(steps.aggregate.outputs.json)) }}
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - id: aggregate
         run: |
           shopt -s globstar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: release
-        uses: ipdxco/changelog-driven-release@v1
+        uses: ipdxco/changelog-driven-release@1c95572a756629544ca0274ad2348b1181173e01 # v1.0.14
         with:
           path: CHANGELOG.md
           draft: ${{ github.event_name == 'pull_request' }}
       - if: github.event_name == 'pull_request' && steps.release.outputs.tag != ''
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: release
           recreate: true

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         source: ${{ fromJSON(inputs.sources) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: version
         name: Determine version
         env:
@@ -88,7 +88,7 @@ jobs:
         env:
           BRANCHES: ${{ inputs.branches }}
           REF: ${{ github.ref }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const branches = JSON.parse(process.env.BRANCHES);
@@ -108,7 +108,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           SHA: ${{ github.sha }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const [owner, repo] = process.env.REPOSITORY.split('/');
@@ -153,7 +153,7 @@ jobs:
       - id: release
         name: Create release
         if: steps.tag.outputs.exists == 'false'
-        uses: galargh/action-gh-release@571276229e7c9e6ea18f99bad24122a4c3ec813f # https://github.com/galargh/action-gh-release/pull/1
+        uses: galargh/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           draft: ${{ inputs.draft }}
           tag_name: ${{ steps.version.outputs.tag }}
@@ -182,7 +182,7 @@ jobs:
           sed 's/[":<>|*?\r\n\\\/]/_/g' <<< "$SOURCE" | xargs -I {} -0 echo "name={}" | tee -a $GITHUB_OUTPUT
       - name: Upload release.json
         if: steps.release.outputs.id != ''
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.json.outputs.name }}
           path: release.json
@@ -193,7 +193,7 @@ jobs:
     outputs:
       json: ${{ toJSON(fromJSON(steps.aggregate.outputs.json)) }}
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - id: aggregate
         run: |
           shopt -s globstar

--- a/.github/workflows/reusable-generated-pr.yml
+++ b/.github/workflows/reusable-generated-pr.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: galargh/stale@main # TODO: replace actions/stale once https://github.com/actions/stale/issues/1136 and https://github.com/actions/stale/issues/1133 are resolved
+      - uses: galargh/stale@b08983672a1d28acfb90b4c4473e94942192d289 # main; TODO: replace actions/stale once https://github.com/actions/stale/issues/1136 and https://github.com/actions/stale/issues/1133 are resolved
         with:
           repo-token: ${{ github.token }}
           stale-pr-message: |

--- a/.github/workflows/reusable-spellcheck.yml
+++ b/.github/workflows/reusable-spellcheck.yml
@@ -12,7 +12,7 @@ jobs:
   spellcheck:
     runs-on: ${{ fromJSON(vars['UCI_SPELLCHECK_RUNNER'] || inputs['runner']) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Extend the GitHub context
         id: github
@@ -29,7 +29,7 @@ jobs:
           fi
 
       - id: config
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require("fs");
@@ -81,7 +81,7 @@ jobs:
           yq -o=json '.' "$CONFIG_PATH" > '.cspell.json'
           rm "$CONFIG_PATH"
 
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           IGNORE_WORDS: |
             Adin
@@ -108,7 +108,7 @@ jobs:
 
       - run: jq . .cspell.json
 
-      - uses: streetsidesoftware/cspell-action@d5d910b521ad408f1e7383c24609079f5a88bdca # v8.2.0
+      - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         with:
           incremental_files_only: ${{
               steps.github.outputs.base_sha && !(

--- a/.github/workflows/reusable-stale-issue.yml
+++ b/.github/workflows/reusable-stale-issue.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: galargh/stale@main # TODO: replace actions/stale once https://github.com/actions/stale/issues/1136 and https://github.com/actions/stale/issues/1133 are resolved
+      - uses: galargh/stale@b08983672a1d28acfb90b4c4473e94942192d289 # main; TODO: replace actions/stale once https://github.com/actions/stale/issues/1136 and https://github.com/actions/stale/issues/1133 are resolved
         with:
           repo-token: ${{ github.token }}
           stale-issue-message: |

--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.UCI_GITHUB_TOKEN }}
       - name: Sync forks
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.UCI_GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Pins direct GitHub Action references in repository workflows and composite actions to immutable commit SHAs. Updates action refs to the latest resolved versions where newer tags exist, including checkout v6.0.2, github-script v9.0.0, artifact actions v7/v8, create-github-app-token v3.1.1, and changelog-driven-release v1.0.14. Expands pin comments to exact tag names where appropriate, while leaving ipdxco/unified-github-workflows and ipfs/aegir comments as main. Leaves generated reusable workflow template fallback behavior unchanged.